### PR TITLE
small change in MMF.hpp

### DIFF
--- a/MMF/MMF.hpp
+++ b/MMF/MMF.hpp
@@ -177,7 +177,7 @@ VECTOR MMF::project(const VECTOR& v, const double eps) const {
 // --- MMF computation --------------------------------------------------------------------------------
 template<class BLOCK>
 MMF::MMF(const BLOCK& M, const MMFparams& params) {
-	const MMFmatrix<BLOCK> B(const_cast<BLOCK>(M), true, true);
+	const MMFmatrix<BLOCK> B(const_cast<BLOCK&>(M), true, true);
 	*this = MMF(B, params);
 }
 


### PR DESCRIPTION
used pointer to BLOCK inside body of MMF(const BLOCK& M, const MMFparams& params)
avoids the error: `const_cast to 'Cmatrix', which is not a reference, pointer-to-object, or pointer-to-data-member` when compiling "randomMMF.cpp" example file from the manual with clang v5.0